### PR TITLE
fix: Fix variable name error in varUseError function

### DIFF
--- a/compileExcelASM16.py
+++ b/compileExcelASM16.py
@@ -45,7 +45,7 @@ def varSequenceError(lineNumber):
     compileResults()
 
 def varUseError(varName):
-    print(RED + "\tVariable cannot be used like label, var: " + str(lineNumber) + ENDCOLOR)
+    print(RED + "\tVariable cannot be used like label, var: " + str(varName) + ENDCOLOR)
     compileResults()
 
 def orgError(lineNumber):


### PR DESCRIPTION
In the `varUseError` function, the print statement incorrectly used the variable name `lineNumber`, which is used by other Error functions, instead of the provided parameter `varName`.